### PR TITLE
Fix broken search result links

### DIFF
--- a/src/ghost-search.js
+++ b/src/ghost-search.js
@@ -18,8 +18,7 @@ class GhostSearch {
             button: '',
             defaultValue: '',
             template: function(result) {
-                let url = [location.protocol, '//', location.url].join('');
-                return '<a href="' + url + '/' + result.slug + '/">' + result.title + '</a>';  
+                return '<a href="/' + result.slug + '/">' + result.title + '</a>';  
             },
             trigger: 'focus',
             options: {


### PR DESCRIPTION
Fixes a bug that causes all search result links to point to `https:///bar/` rather than `https://foo.ghost.io/bar/`.

I'm guessing that this bug was introduced via a find-and-replace mistake in #10.

@NistorCristian 